### PR TITLE
change sr link on logo

### DIFF
--- a/client/src/components/Navbar/Nav.js
+++ b/client/src/components/Navbar/Nav.js
@@ -63,7 +63,7 @@ class Nav extends React.Component {
               <a
                 target="_blank"
                 rel="noopener noreferrer"
-                href="https://streetroots.org/"
+                href="https://news.streetroots.org/"
                 onClick={this.logoDrawerToggle}
               >
                 <img src={srLogo} alt="Street Roots Home" />


### PR DESCRIPTION
Updates in this PR:
- change SR logo link to https://news.streetroots.org/