### PR TITLE
[Experiment] Update config and handle covid_message name change (issue 22) - DO NOT MERGE

### DIFF
--- a/client/src/components/Results/Cards.js
+++ b/client/src/components/Results/Cards.js
@@ -75,7 +75,7 @@ class Card extends React.Component {
       parsedCity: `${record.city}, OR ${record.postal_code}`,
       parsedDescription: cardTextFilter(record.service_description),
       parsedHours: cardTextFilter(record.hours),
-      parsedCOVID: cardTextFilter(record.covid_message),
+      parsedCOVID: cardTextFilter(record.emergency_message),
     };
 
     return (

--- a/config/nodeKeys.js
+++ b/config/nodeKeys.js
@@ -1,12 +1,13 @@
-//these ids are public facing
-// module.exports = {
-//     NODE_PACKAGE_ID: "e9c55b2c-4019-463e-8efa-622f23221402",
-//     NODE_LISTING_RESOURCE: "9be4623a-3c01-4b2d-9c7b-567a41abbc1c",
-//     NODE_PHONE_RESOURCE: "2f66ad5d-5066-49d8-846a-6751cfd23863"
-// }
-
-module.exports = {
+if (process.env.NODE_ENV === "production") {
+  module.exports = {
+    NODE_PACKAGE_ID: "e9c55b2c-4019-463e-8efa-622f23221402",
+    NODE_LISTING_RESOURCE: "9be4623a-3c01-4b2d-9c7b-567a41abbc1c",
+    NODE_PHONE_RESOURCE: "2f66ad5d-5066-49d8-846a-6751cfd23863",
+  };
+} else {
+  module.exports = {
     NODE_PACKAGE_ID: "592c18db-efa6-44c6-8477-4ffa4103ba94",
     NODE_LISTING_RESOURCE: "61cee891-7d0f-4ebe-b8ea-c0c8d6cb27e7",
-    NODE_PHONE_RESOURCE: "4407461b-e99d-4d8e-8a44-18483aa8d13c"
+    NODE_PHONE_RESOURCE: "4407461b-e99d-4d8e-8a44-18483aa8d13c",
+  };
 }

--- a/config/nodeKeys.js
+++ b/config/nodeKeys.js
@@ -1,6 +1,12 @@
 //these ids are public facing
+// module.exports = {
+//     NODE_PACKAGE_ID: "e9c55b2c-4019-463e-8efa-622f23221402",
+//     NODE_LISTING_RESOURCE: "9be4623a-3c01-4b2d-9c7b-567a41abbc1c",
+//     NODE_PHONE_RESOURCE: "2f66ad5d-5066-49d8-846a-6751cfd23863"
+// }
+
 module.exports = {
-    NODE_PACKAGE_ID: "e9c55b2c-4019-463e-8efa-622f23221402",
-    NODE_LISTING_RESOURCE: "9be4623a-3c01-4b2d-9c7b-567a41abbc1c",
-    NODE_PHONE_RESOURCE: "2f66ad5d-5066-49d8-846a-6751cfd23863"
+    NODE_PACKAGE_ID: "592c18db-efa6-44c6-8477-4ffa4103ba94",
+    NODE_LISTING_RESOURCE: "61cee891-7d0f-4ebe-b8ea-c0c8d6cb27e7",
+    NODE_PHONE_RESOURCE: "4407461b-e99d-4d8e-8a44-18483aa8d13c"
 }


### PR DESCRIPTION
This is a quick PR that addresses #22.  Changes made:
- update config to point to dev resources we can use for testing
- change `covid_message` to `emergency_message` in the `Cards` component.  

The following URI will surface the new main categories.
`<hostname>/results?category=Fire%20Assistance%20Resource%20-%20Health&category=Fire%20Assistance%20Resource%20-%20Care&category=Fire%20Assistance%20Resource%20-%20Food&`

or we can use the more general URI:
`<hostname>/results?search=fire%20assistance%20resource`

cc @isthewhiz @wrunion 